### PR TITLE
attempted to add a whitelist of 'vm' and 'vc' to the swiftLint exceptions.

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -119,6 +119,8 @@ identifier_name:
     - x
     - y
     - z
+    - vm
+    - vc
 
 multiline_arguments:
   first_argument_location: next_line


### PR DESCRIPTION
attempted to add a whitelist of 'vm' and 'vc' to the swiftLint exceptions.