### PR TITLE
Ignored files in Ejerskifte

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,7 +1,9 @@
 excluded:
-  - ${PWD}/Ejerskifte/Sources/Shared/Translations
+#Ejerskifte ignores
+  - ${PWD}/Shared/Sources/Shared/Translations
   - ${PWD}/Ejerskifte/Tests
-
+  - ${PWD}/Authentication/Tests
+  - ${PWD}/AppController/Tests
 
 whitelist_rules:
 #opt_in_rules:


### PR DESCRIPTION
Updated ignored folders so swiftlint works with the new package structure in Ejerskifte. 
So now we ignore all tests and autogenerated translation files.